### PR TITLE
Fix Cuckoo bug where logger is given wrong debug arguments

### DIFF
--- a/cuckoo/root_node.py
+++ b/cuckoo/root_node.py
@@ -96,7 +96,12 @@ class RootNode(BinaryTreeNode[TMODEL]):
                 self._session = Client(timeout=None)
             return self._session
 
-    def _process_response(self, response: Response, query: str, variables: dict):
+    def _process_response(
+        self,
+        response: Response,
+        query: str,
+        variables: dict,
+    ):
         response.raise_for_status()
         response_json: dict[str, Any] = response.json()
 
@@ -106,20 +111,17 @@ class RootNode(BinaryTreeNode[TMODEL]):
             ) + response_json.get("errors", [])
             if self._logger:
                 self._logger.error(
-                    "Query failed. query=%s, variables=%s, response=%s",
-                    self._compact(query),
-                    to_truncated_str(variables),
-                    str(errors),
+                    f"Query failed. query={self._compact(query)}, "
+                    f"variables={to_truncated_str(variables)}, response={str(errors)}."
                 )
             raise HasuraServerError(errors)
 
         elif "data" in response_json:
             if self._logger:
                 self._logger.debug(
-                    "Query successful. query=%s, variables=%s, response=%s",
-                    self._compact(query),
-                    to_truncated_str(variables),
-                    to_truncated_str(response_json["data"]),
+                    f"Query successful. query={self._compact(query)}, "
+                    f"variables={to_truncated_str(variables)}, "
+                    f"response={to_truncated_str(response_json['data'])}."
                 )
             return response_json["data"]
 
@@ -137,10 +139,8 @@ class RootNode(BinaryTreeNode[TMODEL]):
 
         if self._logger:
             self._logger.debug(
-                "Executing Query. query=%s, variables=%s, config=%s",
-                self._compact(query),
-                to_truncated_str(variables),
-                self._config,
+                f"Executing query. query={self._compact(query)}, "
+                f"variables={to_truncated_str(variables)}."
             )
 
         session = self._get_or_create_session()
@@ -171,10 +171,8 @@ class RootNode(BinaryTreeNode[TMODEL]):
 
         if self._logger:
             self._logger.debug(
-                "Executing Query. query=%s, variables=%s, config=%s",
-                self._compact(query),
-                to_truncated_str(variables),
-                self._config,
+                f"Executing async query. query={self._compact(query)}, "
+                f"variables={to_truncated_str(variables)}."
             )
 
         session = self._get_or_create_session(use_async=True)

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,5 +1,5 @@
 coverage==7.*
-geojson-pydantic>=0     # pydantic v1 and v2 supported
+geojson-pydantic==0.*     # uses pydantic v1
 pytest-asyncio==0.*
 pytest-watch==4.*
 pytest==7.*

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -128,14 +128,10 @@ class TestOneByPK:
                 caplog.records,
             )
         )
-        assert record.args
-        query, variables, result = record.args
-        assert isinstance(query, str) and "authors_by_pk" in query
-        assert isinstance(variables, str) and str(existing_uuid) in variables
-        assert (
-            isinstance(result, str)
-            and f"{{'name': '{persisted_authors[0].name}'}}" in result
-        )
+        assert record
+        assert "authors_by_pk" in record.msg
+        assert str(existing_uuid) in record.msg
+        assert f"{{'name': '{persisted_authors[0].name}'}}" in record.msg
 
     async def test_failed_query_gets_logged(
         self,
@@ -169,14 +165,10 @@ class TestOneByPK:
                 caplog.records,
             )
         )
-        assert record.args
-        query, variables, errors = record.args
-        assert isinstance(query, str) and "authors_by_pk" in query
-        assert isinstance(variables, str) and str(existing_uuid) in variables
-        assert (
-            isinstance(errors, str)
-            and "field 'does_not_exist' not found in type: 'authors'" in errors
-        )
+        assert record
+        assert "authors_by_pk" in record.msg
+        assert str(existing_uuid) in record.msg
+        assert "field 'does_not_exist' not found in type: 'authors'" in record.msg
 
 
 @mark.parametrize(**FinalizeParams(Query).returning_many())
@@ -783,9 +775,11 @@ class TestBatch:
                 session=session,
             ) as BatchQuery:
                 with raises(AttributeError):
-                    BatchQuery(Author).one_by_pk(
-                        uuid=persisted_authors[0].uuid
-                    ).returning(),
+                    (
+                        BatchQuery(Author)
+                        .one_by_pk(uuid=persisted_authors[0].uuid)
+                        .returning(),
+                    )
 
                 with raises(AttributeError):
                     BatchQuery(Author).many().returning()
@@ -799,9 +793,11 @@ class TestBatch:
         with raises(HasuraServerError):
             async with Query.batch_async(session_async=session_async) as BatchQuery:
                 with raises(AttributeError):
-                    BatchQuery(Author).one_by_pk(
-                        uuid=persisted_authors[0].uuid
-                    ).returning(),
+                    (
+                        BatchQuery(Author)
+                        .one_by_pk(uuid=persisted_authors[0].uuid)
+                        .returning(),
+                    )
 
                 with raises(AttributeError):
                     BatchQuery(Author).many().returning()


### PR DESCRIPTION
## Problem
Description

When passing a logger to an async query we get an error about too many arguments. The offending line is: 

https://github.com/hotaru355/cuckoo-hasura/blob/main/cuckoo/root_node.py#L173

The fix to this issue was to remove the logger, as shown here: https://github.com/heliolyticsinc/anomaly-management-service/pull/126/files#diff-9f7492c119c14173135c721af61a680292486c259ed9a605a28e189040039472L20

https://dronebase.atlassian.net/browse/DAN-301

## Changes

- changed all logging calls to use a single str arg.

## Steps to Test or Reproduce

run tests
