### PR TITLE
move session setup into global configurator

### DIFF
--- a/cuckoo/__init__.py
+++ b/cuckoo/__init__.py
@@ -1,7 +1,3 @@
-from typing import Optional
-
-from httpx import AsyncClient, Client
-
 import cuckoo.errors
 import cuckoo.models
 import cuckoo.utils

--- a/cuckoo/__init__.py
+++ b/cuckoo/__init__.py
@@ -1,7 +1,18 @@
+from typing import Optional
+
+from httpx import AsyncClient, Client
+
 import cuckoo.errors
 import cuckoo.models
 import cuckoo.utils
-from cuckoo.constants import ORDER_BY, ORDER_DIRECTION, WHERE, CuckooConfig
+from cuckoo.constants import (
+    ORDER_BY,
+    ORDER_DIRECTION,
+    WHERE,
+    CuckooConfig,
+    GlobalCuckooConfig,
+)
+from cuckoo.cuckoo import Cuckoo
 from cuckoo.delete import Delete
 from cuckoo.finalizers import (
     TFIN_AGGR,

--- a/cuckoo/constants.py
+++ b/cuckoo/constants.py
@@ -13,8 +13,14 @@ from typing import (
 )
 
 from httpx import AsyncClient, Client
-from tenacity import stop_after_attempt, wait_random_exponential
+from tenacity import (
+    retry_if_not_exception_type,
+    stop_after_attempt,
+    wait_random_exponential,
+)
 from typing_extensions import NotRequired, TypeAlias
+
+from cuckoo.errors import HasuraServerError
 
 if TYPE_CHECKING:
     from tenacity import RetryCallState, RetryError
@@ -39,9 +45,9 @@ class GlobalCuckooConfig(TypedDict):
 
 
 class CuckooConfig(TypedDict):
-    url: str
-    headers: dict[str, str]
-    retry: RetryConfig
+    url: NotRequired[str]
+    headers: NotRequired[dict[str, str]]
+    retry: NotRequired[RetryConfig]
 
 
 class RetryConfig(TypedDict):
@@ -64,6 +70,7 @@ HASURA_HEADERS = {
 RETRY_DEFAULT_CONFIG: RetryConfig = {
     "wait": wait_random_exponential(multiplier=1, max=60),
     "stop": stop_after_attempt(5),
+    "retry": retry_if_not_exception_type(HasuraServerError),
 }
 HASURA_DEFAULT_CONFIG: CuckooConfig = {
     "url": HASURA_URL,

--- a/cuckoo/cuckoo.py
+++ b/cuckoo/cuckoo.py
@@ -1,0 +1,45 @@
+from typing import Optional
+
+from httpx import AsyncClient, Client
+
+from .constants import HASURA_DEFAULT_CONFIG, CuckooConfig, GlobalCuckooConfig
+
+
+class Cuckoo:
+    _global_config: GlobalCuckooConfig = {
+        "session": None,
+        "session_async": None,
+        "cuckoo_config": HASURA_DEFAULT_CONFIG.copy(),
+    }
+
+    @classmethod
+    def configure(
+        cls,
+        cuckoo_config: Optional[CuckooConfig] = None,
+        *,
+        session: Optional[Client] = None,
+        session_async: Optional[AsyncClient] = None,
+    ):
+        for name, prop in [
+            ("cuckoo_config", cuckoo_config),
+            ("session", session),
+            ("session_async", session_async),
+        ]:
+            if prop is not None:
+                cls._global_config[name] = prop
+
+    @classmethod
+    def cuckoo_config(cls, *config: CuckooConfig):
+        merged_config = Cuckoo._global_config["cuckoo_config"].copy()
+        for cfg in config:
+            merged_config.update(cfg)
+
+        return merged_config
+
+    @classmethod
+    def session(cls):
+        return cls._global_config["session"]
+
+    @classmethod
+    def session_async(cls):
+        return cls._global_config["session_async"]

--- a/cuckoo/cuckoo.py
+++ b/cuckoo/cuckoo.py
@@ -21,7 +21,13 @@ class Cuckoo:
         session_async: Optional[AsyncClient] = None,
     ):
         for name, prop in [
-            ("cuckoo_config", cuckoo_config),
+            (
+                "cuckoo_config",
+                {
+                    **cls._global_config["cuckoo_config"],
+                    **(cuckoo_config if cuckoo_config else {}),
+                },
+            ),
             ("session", session),
             ("session_async", session_async),
         ]:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "cuckoo-hasura"
-version = "0.1.8"
+version = "0.2.0"
 description = "An easy to use GraphQL query builder, optimized for Hasura."
 readme = "README.md"
 requires-python = ">=3.9"

--- a/tests/test_cuckoo.py
+++ b/tests/test_cuckoo.py
@@ -1,0 +1,320 @@
+from unittest.mock import MagicMock, patch
+
+from httpx import AsyncClient, Client
+from pytest import fixture, mark, raises
+
+from cuckoo.constants import HASURA_DEFAULT_CONFIG, HASURA_HEADERS, HASURA_URL
+from cuckoo.cuckoo import Cuckoo
+from cuckoo.errors import HasuraClientError, HasuraServerError
+from cuckoo.query import Query
+from tests.fixture.sample_models.public import Author
+
+
+@fixture
+def spy_session():
+    session = Client()
+    with patch.object(session, "send", wraps=session.send) as spy_send:
+        yield session, spy_send
+
+
+@fixture
+def spy_session2():
+    session = Client()
+    with patch.object(session, "send", wraps=session.send) as spy_send:
+        yield session, spy_send
+
+
+@fixture
+def spy_session_async():
+    session = AsyncClient()
+    with patch.object(session, "send", wraps=session.send) as spy_send:
+        yield session, spy_send
+
+
+@fixture
+def spy_session_async2():
+    session = AsyncClient()
+    with patch.object(session, "send", wraps=session.send) as spy_send:
+        yield session, spy_send
+
+
+@fixture
+def clear_env_vars():
+    """Configure cuckoo as if it had no Hasura env vars set.
+    If the env vars were actually cleared, pre-test DB migrations would fail
+    TODO: move migration into container build
+    """
+    Cuckoo.configure(
+        cuckoo_config={
+            "headers": None,
+            "url": None,
+        },  # type: ignore
+    )
+    # remove setup from any previous tests
+    Cuckoo._global_config["session"] = None
+    Cuckoo._global_config["session_async"] = None
+
+
+@fixture
+def default_env_vars():
+    Cuckoo.configure(
+        cuckoo_config=HASURA_DEFAULT_CONFIG,
+    )
+    # remove setup from any previous tests
+    Cuckoo._global_config["session"] = None
+    Cuckoo._global_config["session_async"] = None
+
+
+@mark.asyncio(scope="session")
+class TestConfigure:
+    @mark.usefixtures("clear_env_vars")
+    async def test_missing_url_raises_error(self, session: Client):
+        Cuckoo.configure(
+            cuckoo_config={
+                # URL missing
+                "headers": HASURA_DEFAULT_CONFIG["headers"],
+            }
+        )
+
+        with raises(HasuraClientError, match="Missing Hasura server URL"):
+            Query(Author, session=session).many(where={}).returning()
+
+    @mark.skip(
+        reason="Currently a bug: errors from Hasura are swallowed in streaming mode"
+    )
+    @mark.usefixtures("clear_env_vars")
+    async def test_missing_headers_for_streamed_query_raises_error(
+        self, session: Client
+    ):
+        Cuckoo.configure(
+            cuckoo_config={
+                # headers missing
+                "url": HASURA_DEFAULT_CONFIG["url"],
+            }
+        )
+
+        with raises(
+            HasuraServerError, match="x-hasura-access-key required, but not found"
+        ):
+            Query(Author, session=session).many(where={}).returning()
+
+    @mark.usefixtures("clear_env_vars")
+    async def test_missing_headers_for_async_query_raises_error(
+        self, session_async: AsyncClient
+    ):
+        Cuckoo.configure(
+            cuckoo_config={
+                # headers missing
+                "url": HASURA_DEFAULT_CONFIG["url"],
+            }
+        )
+
+        with raises(
+            HasuraServerError, match="x-hasura-access-key required, but not found"
+        ):
+            await (
+                Query(Author, session_async=session_async)
+                .many(where={})
+                .returning_async()
+            )
+
+    @mark.usefixtures("default_env_vars")
+    async def test_url_and_headers_can_be_set_by_env_vars(self, session: Client):
+        # fixture sets env vars
+
+        query = Query(Author, session=session)
+        authors = query.many(where={}).returning()
+
+        assert authors == []
+        assert Cuckoo.cuckoo_config()["url"] == query._config["url"] == HASURA_URL
+        assert (
+            Cuckoo.cuckoo_config()["headers"]
+            == query._config["headers"]
+            == HASURA_HEADERS
+        )
+
+    @mark.usefixtures("clear_env_vars")
+    async def test_url_and_headers_can_can_be_set_by_configure(self, session):
+        assert Cuckoo.cuckoo_config()["url"] is None
+        assert Cuckoo.cuckoo_config()["headers"] is None
+
+        Cuckoo.configure(
+            cuckoo_config={
+                "url": HASURA_URL,
+                "headers": HASURA_HEADERS,
+            }
+        )
+        query = Query(Author, session=session)
+        authors = query.many(where={}).returning()
+
+        assert authors == []
+        assert Cuckoo.cuckoo_config()["url"] == query._config["url"] == HASURA_URL
+        assert (
+            Cuckoo.cuckoo_config()["headers"]
+            == query._config["headers"]
+            == HASURA_HEADERS
+        )
+
+    @mark.usefixtures("clear_env_vars")
+    async def test_url_and_headers_can_can_be_set_by_constructor(self, session: Client):
+        assert Cuckoo.cuckoo_config()["url"] is None
+        assert Cuckoo.cuckoo_config()["headers"] is None
+
+        query = Query(
+            Author,
+            session=session,
+            config={
+                "url": HASURA_URL,
+                "headers": HASURA_HEADERS,
+            },
+        )
+        authors = query.many(where={}).returning()
+
+        assert authors == []
+        assert (
+            Cuckoo.cuckoo_config()["url"] is None
+        ), "settting the URL on a query should not set it on the global config"
+        assert (
+            Cuckoo.cuckoo_config()["headers"] is None
+        ), "settting the headers on a query should not set them on the global config"
+        assert query._config["url"] == HASURA_URL
+        assert query._config["headers"] == HASURA_HEADERS
+
+    @mark.usefixtures("clear_env_vars")
+    async def test_url_and_headers_set_by_constructor_take_precedence_over_global_settings(
+        self, session: Client
+    ):
+        Cuckoo.configure(
+            cuckoo_config={
+                "url": "globalurl",
+                "headers": {"test-header": "test"},
+            }
+        )
+
+        query = Query(
+            Author,
+            session=session,
+            config={
+                "url": HASURA_URL,
+                "headers": HASURA_HEADERS,
+            },
+        )
+        authors = query.many(where={}).returning()
+
+        assert authors == []
+        assert query._config["url"] == HASURA_URL
+        assert query._config["headers"] == HASURA_HEADERS
+
+    @mark.usefixtures("default_env_vars")
+    async def test_session_can_be_set_by_configure(
+        self,
+        spy_session: tuple[Client, MagicMock],
+    ):
+        session, spy_send = spy_session
+
+        Cuckoo.configure(session=session)
+        query = Query(Author)
+        authors = query.many(where={}).returning()
+
+        spy_send.assert_called_once()
+        assert authors == []
+        assert query.session == session
+
+    @mark.usefixtures("default_env_vars")
+    async def test_async_session_can_be_set_by_configure(
+        self,
+        spy_session_async: tuple[AsyncClient, MagicMock],
+    ):
+        session_async, spy_send = spy_session_async
+
+        Cuckoo.configure(session_async=session_async)
+        query = Query(Author)
+        authors = await query.many(where={}).returning_async()
+
+        spy_send.assert_called_once()
+        assert authors == []
+        assert query.session_async == session_async
+
+    @mark.usefixtures("default_env_vars")
+    async def test_session_can_be_set_by_constructor(
+        self,
+        spy_session: tuple[Client, MagicMock],
+    ):
+        session, spy_send = spy_session
+
+        query = Query(Author, session=session)
+        authors = query.many(where={}).returning()
+
+        spy_send.assert_called_once()
+        assert authors == []
+        assert query.session == session
+
+    @mark.usefixtures("default_env_vars")
+    async def test_async_session_can_be_set_by_constructor(
+        self,
+        spy_session_async: tuple[AsyncClient, MagicMock],
+    ):
+        session_async, spy_send = spy_session_async
+
+        query = Query(Author, session_async=session_async)
+        authors = await query.many(where={}).returning_async()
+
+        spy_send.assert_called_once()
+        assert authors == []
+        assert query.session_async == session_async
+
+    @mark.usefixtures("default_env_vars")
+    async def test_session_set_by_constructor_takes_precedence_over_global_session(
+        self,
+        spy_session: tuple[Client, MagicMock],
+        spy_session2: tuple[Client, MagicMock],
+    ):
+        session_local, spy_send_local = spy_session
+        session_global, spy_send_global = spy_session2
+
+        Cuckoo.configure(session=session_global)
+        query = Query(Author, session=session_local)
+        authors = query.many(where={}).returning()
+
+        spy_send_local.assert_called_once()
+        spy_send_global.assert_not_called()
+        assert authors == []
+        assert query.session == session_local
+
+    @mark.usefixtures("default_env_vars")
+    async def test_async_session_set_by_constructor_takes_precedence_over_global_session(
+        self,
+        spy_session_async: tuple[AsyncClient, MagicMock],
+        spy_session_async2: tuple[AsyncClient, MagicMock],
+    ):
+        session_async_local, spy_send_local = spy_session_async
+        session_async_global, spy_send_global = spy_session_async2
+
+        Cuckoo.configure(session_async=session_async_global)
+        query = Query(Author, session_async=session_async_local)
+        authors = await query.many(where={}).returning_async()
+
+        spy_send_local.assert_called_once()
+        spy_send_global.assert_not_called()
+        assert authors == []
+        assert query.session_async == session_async_local
+
+    @mark.usefixtures("default_env_vars")
+    async def test_missing_session_raises_error(self):
+        query = Query(Author)
+
+        with raises(HasuraClientError, match="No session provided"):
+            query.many(where={}).returning()
+
+        with raises(HasuraClientError, match="No session provided"):
+            query.session
+
+    @mark.usefixtures("default_env_vars")
+    async def test_missing_async_session_raises_error(self):
+        query = Query(Author)
+
+        with raises(HasuraClientError, match="No async session provided"):
+            await query.many(where={}).returning_async()
+
+        with raises(HasuraClientError, match="No async session provided"):
+            query.session_async

--- a/tests/test_include.py
+++ b/tests/test_include.py
@@ -296,11 +296,16 @@ class TestAggregate:
 
 def test_raises_error_if_instance_is_used_more_than_once(
     persisted_author: Author,
+    session: Client,
 ):
     columns = [Include(Article).many().returning()]
-    Query(Author).one_by_pk(uuid=persisted_author.uuid).returning(columns)
+    Query(Author, session=session).one_by_pk(uuid=persisted_author.uuid).returning(
+        columns
+    )
     with raises(ValueError) as error:
-        Query(Author).one_by_pk(uuid=persisted_author.uuid).returning(columns)
+        Query(Author, session=session).one_by_pk(uuid=persisted_author.uuid).returning(
+            columns
+        )
     assert (
         "Found an instance `Include(Article)` that was already used in an executed query"
     ) in str(error)

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -409,7 +409,7 @@ class TestManyYielding:
         print("START ", datetime.now().isoformat())
         count = 0
         # for author in await Query(Author).many(where={}).returning_async():
-        for author in Query(Author).many(where={}).yielding():
+        for author in Query(Author, session=session).many(where={}).yielding():
             # assert isinstance(author.uuid, UUID)
             count += 1
         print("END ", count, datetime.now().isoformat())


### PR DESCRIPTION
## Problem

version `0.1.8` introduced streaming HTTP data through the `Query().many().yielding()` method. This only works when providing a session; if you let cuckoo create a default session, it will close the internal session before the iterator is exhausted.

See also: https://zeitview.slack.com/archives/C05UXBCUUT0/p1714763423552319

It is not possible for cuckoo to close a default session, since it cannot know when/if the generator got exhausted. Instead, it is now the users responsibility to **always** provide a session and close it when required. To ease the setup of a default session, this PR introduces a small setup method that stores a global session for any use where cuckoo would otherwise use an internal session.

## Changes

- added `Cuckoo` class with `configure` method
- 
## Steps to Test or Reproduce

How can people test it manually?

## Related PRs

List related PRs against other projects/branches
